### PR TITLE
Rename to `tsfeaturex`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Description: Inspired by tsfresh, this package calculate numerous features on an
 Imports: e1071, entropy, Langevin, Hmisc, forecast, stats, zoo, psych
 Depends: R (>= 3.4.0), tidyverse
 License: MIT
-URL: https://github.com/nelsonroque/featuRe
+URL: https://github.com/nelsonroque/tsfeaturex
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.1.1

--- a/R/extract_features.R
+++ b/R/extract_features.R
@@ -21,7 +21,7 @@ extract_features <- function(df, group_var, value_var, features='all', custom_fe
   #' 
   
   #' storing for multiple downstream purposes
-  VERSION_CODE = packageVersion("featuRe")
+  VERSION_CODE = utils::packageVersion("tsfeaturex")
   
   #' 
   

--- a/R/features_to_df.R
+++ b/R/features_to_df.R
@@ -12,7 +12,7 @@
 
 #' @export
 features_to_df <- function(df.list, group_var, data.format = "long", verbose=F) {
-  VERSION_CODE = packageVersion("featuRe")
+  VERSION_CODE = utils::packageVersion("tsfeaturex")
   
   # check list to make sure it is mergeable
   if(length(df.list) > 1){


### PR DESCRIPTION
Maybe because the old name (featuRe) is used, the demo code does not work.

``` r
library(tsfeaturex)
#> Loading required package: tidyverse

set.seed(516)

dat <- data.frame(expand.grid(day=c(1:7),id=c(1:100)))
dat$y <- rnorm(nrow(dat),5,1.5)
dat$y[1:3] <- NA

out.list <- extract_features(df=dat,group_var="id",value_var="y",features="all")
#> Error in packageVersion("featuRe"): package 'featuRe' not found
```

<sup>Created on 2019-03-06 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

I added a commit to fix this. `extract_features()` now works.